### PR TITLE
Mochi flashcards prompt wording

### DIFF
--- a/app/api/mochi-flashcards/route.ts
+++ b/app/api/mochi-flashcards/route.ts
@@ -202,7 +202,6 @@ function buildOpenAIPrompt(topic: string): string {
 Create flashcards about this topic: "${topic}".
 
 Flashcard quality rules:
-- Prioritize understanding over trivia.
 - Keep front concise and clear.
 - Keep back concise but complete. No more than a sentence. 
 - Include specific facts, definitions, examples, or contrasts when useful.


### PR DESCRIPTION
Remove 'Prioritize understanding over trivia' from the Mochi Flashcards OpenAI prompt.

---
<p><a href="https://cursor.com/agents?id=bc-d9a6f440-9227-4e73-ad43-38ed388c2e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9a6f440-9227-4e73-ad43-38ed388c2e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prompt-text change only; no functional logic, auth, or data handling paths are modified.
> 
> **Overview**
> Adjusts the Mochi flashcards OpenAI prompt by removing the “Prioritize understanding over trivia” rule from the generated instructions, leaving the rest of the formatting/JSON-shape constraints unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6e374753d085c879f885674a89c18bf2bb63016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->