### PR TITLE
Update Khalid Belhadj link

### DIFF
--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -79,7 +79,7 @@ const people: Record<Person, PersonDetails> = {
   },
   [Person.KhalidBelhadj]: {
     name: 'Khalid Belhadj',
-    link: 'https://khalidbelhadj.github.io/portfolio/',
+    link: 'https://www.khalidbelhadj.com/',
     url: 'https://unavatar.io/github/khalidbelhadj',
   },
   [Person.LexFridman]: {


### PR DESCRIPTION
## What changed

- Updated Khalid Belhadj’s profile link to his current personal website.

## Why

The previous GitHub Pages portfolio URL is obsolete. Visitors will now be directed to `https://www.khalidbelhadj.com/`.

## Validation

- Confirmed the new destination returns HTTP 200.
- Ran the focused lint check for `components/ui/avatar.tsx` successfully.